### PR TITLE
changed the light tank's cost from $700 to $600

### DIFF
--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -38,7 +38,7 @@ V2RL:
 		BuildPaletteOrder: 50
 		Prerequisites: ~vehicles.allies, ~techlevel.low
 	Valued:
-		Cost: 700
+		Cost: 600
 	Tooltip:
 		Name: Light Tank
 		Description: Light Tank, good for scouting.\n  Strong vs Light armor\n  Weak vs Infantry, Tanks, Aircraft


### PR DESCRIPTION
this was done because the medium tank (far better than the light) costs only $150 more than the light tank which basicly gives people no reason to build the light tank after they get out a service depo

at the same time the hum-v costs $500 so you wouldn't want people to have a better alternative
but then again the hum-v counters infantry so it has its own purpose.